### PR TITLE
fix dir="auto" issue in RichText component

### DIFF
--- a/src/view/com/util/text/RichText.tsx
+++ b/src/view/com/util/text/RichText.tsx
@@ -3,7 +3,7 @@ import {TextStyle, StyleProp} from 'react-native'
 import {RichText as RichTextObj, AppBskyRichtextFacet} from '@atproto/api'
 import {TextLink} from '../Link'
 import {Text} from './Text'
-import {lh} from 'lib/styles'
+import {lh, s} from 'lib/styles'
 import {toShortUrl} from 'lib/strings/url-helpers'
 import {useTheme, TypographyVariant} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -51,7 +51,7 @@ export function RichText({
       <Text
         testID={testID}
         type={type}
-        style={[style, pal.text, lineHeightStyle]}
+        style={[style, pal.text, s.flex1, lineHeightStyle]}
         // @ts-ignore web only -prf
         dataSet={WORD_WRAP}>
         {text}


### PR DESCRIPTION
There's a problem with dir="auto" that it doesn't work for RTL languages, by adding flex: 1 to the text component it will be fixed.

the issue:

<img width="597" alt="image" src="https://github.com/rezaaa/social-app/assets/2494766/8f62cb6e-6f9f-4081-a1db-8b4cf585ca1d">
<img width="595" alt="image" src="https://github.com/rezaaa/social-app/assets/2494766/8d6b7fe8-058b-4ab2-9746-ab09d3850b6a">
